### PR TITLE
Use string format specifier for l10n

### DIFF
--- a/src/widgets/HeaderBar.vala
+++ b/src/widgets/HeaderBar.vala
@@ -128,7 +128,7 @@ namespace Cipher.Widgets {
         }
 
         public void set_wiki_link_tooltip_text (string title) {
-            wiki_link.tooltip_text = _("Click to learn more about ") + title + _(" on Wikipedia");
+            wiki_link.tooltip_text = _("Click to learn more about %s on Wikipedia").printf (title);
         }
 
         private bool on_button_released (Gtk.Widget sender, Gdk.EventButton event) {


### PR DESCRIPTION
![2019-01-31 20 08 10](https://user-images.githubusercontent.com/26003928/52050577-5603fc00-2594-11e9-9077-aca49f6c970e.png)

In some languages, the idiom "learn about A" (A is an object to learn) is not put in this order. In the case of Japanese, we translate it as "A について知る":  first put A, and the next is "about", and then "learn".
This PR allows translators putting `title` string anywhere of their translations for cases like this.
